### PR TITLE
Feature/theme - Create a template of theme

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -44,19 +44,19 @@ export const fonts = {
   heading: {
     color: colors.foreground,
     fontSize: 24,
-    fontWeight: '800' as '800',
+    fontWeight: '800',
   },
   subheading: {
     color: colors.foreground,
     fontSize: 18,
-    fontWeight: '500' as '500',
+    fontWeight: '500',
   },
   caption: {
     color: colors.foreground,
     fontSize: 16,
-    fontWeight: '400' as '400',
+    fontWeight: '400',
   },
-};
+} as const;
 
 export const opacity = {
   initial: 1,

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,0 +1,65 @@
+import {Dimensions} from 'react-native';
+
+export const sizes = {
+  zero: 0,
+  xs: 4,
+  sm: 8,
+  md: 12,
+  lg: 16,
+  xl: 24,
+  icon: 32,
+  screenWidth: Dimensions.get('screen').width,
+  screenHeight: Dimensions.get('screen').height,
+  '1/2': '50%',
+  '1/3': '33.333%',
+  '2/3': '66.666%',
+  '1/4': '25%',
+  '2/4': '50%',
+  '3/4': '75%',
+  '1/5': '20%',
+  '2/5': '40%',
+  '3/5': '60%',
+  '4/5': '80%',
+  full: '100%',
+  auto: 'auto',
+};
+
+export const borderRadius = {
+  sm: 4,
+  md: 8,
+  lg: 12,
+  xl: 16,
+  circle: 999,
+};
+
+export const colors = {
+  transparent: 'transparent',
+  background: '#27374D',
+  secondaryBackground: '#526D82',
+  foreground: '#DDE6ED',
+  secondaryForeground: '#9DB2BF',
+};
+
+export const fonts = {
+  heading: {
+    color: colors.foreground,
+    fontSize: 24,
+    fontWeight: '800' as '800',
+  },
+  subheading: {
+    color: colors.foreground,
+    fontSize: 18,
+    fontWeight: '500' as '500',
+  },
+  caption: {
+    color: colors.foreground,
+    fontSize: 16,
+    fontWeight: '400' as '400',
+  },
+};
+
+export const opacity = {
+  initial: 1,
+  active: 0.7,
+  inactive: 0.3,
+};

--- a/src/theme/package.json
+++ b/src/theme/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@app/theme"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,9 @@
       "@app/components/*": [
         "./components/*"
       ],
+      "@app/theme/*": [
+        "./theme/*"
+      ],
     },
   }
 }


### PR DESCRIPTION
I created a basic template of theme. These styles should be used across the app to unify and simplify work. 
Also, added `@app/theme` as a path.

- `sizes` - keeps a grid. These values could be used as `width`, `height`, `padding`, `margin`, etc.
- `borderRadius` - keeps basic border radius values. Does not inherit `sizes` because it has different purpose.
- `colors` - it works based on where a color will be used:
  -  `background/secondaryBackground` for view backgrounds
  - `foreground/secondaryForeground` for texts
- `fonts` - keeps 3 variants of texts across the app.
- `opacity` - keeps 3 main variants: 
  - `initial` - no transparent effect
  - `active` - used for `activeOpacity` of `TouchableOpacity`
  - `inactive` - used for disabled views